### PR TITLE
New format for revyos-{lcon4a,lpi4a}

### DIFF
--- a/riko/cli/manifests.py
+++ b/riko/cli/manifests.py
@@ -101,32 +101,42 @@ def manifests(up_name: str, gen_vers: List[str], down_grade: bool):
         assert riko_yaml_orig["format"] == "v1"
 
         # riko.yaml parsing functions
-        def tree_update_inner(key: str, value: Dict | List | str) -> Dict:
+        def tree_parse_inner(key: str, value: Dict | List | str) -> Dict:
             if isinstance(value, Dict):
                 tree_new = {}
                 for k, v in value.items():
-                    tree_new.update(tree_update_inner(k, v))
+                    tree_new.update(tree_parse_inner(k, v))
 
                 return {key: tree_new}
             elif isinstance(value, List):
                 list_new = []
                 if isinstance(value[0], Dict):
                     for v in value:
-                        list_new.append(tree_update_inner("k", v)["k"])
+                        list_new.append(tree_parse_inner("k", v)["k"])
                 elif isinstance(value[0], str):
                     for s in value:
-                        list_new.append(tree_update_inner("k", s)["k"])
+                        list_new.append(tree_parse_inner("k", s)["k"])
                 else:
                     raise RuntimeError(f"Unexpected type {type(value)}")
                 return {key: list_new}
             elif isinstance(value, str):
+                # remain some str unchanged as str
                 if re.match(r"^[a-zA-Z0-9 ,\-+.]+$", value):
                     return {key: value}
+                # treat rest str as expr
                 return {key: ast.parse(value, mode="eval")}
             elif value is None:
                 return {key: ""}
             else:
                 raise RuntimeError(f"Unexpected type {type(value)}")
+
+        def tree_update_inner(tree_old: Dict, tree_up: Dict) -> None:
+            for k in tree_up.keys():
+                if k in tree_old.keys() and isinstance(tree_old[k], Dict) and isinstance(tree_up[k], Dict):
+                    # keep old keys in old Dict
+                    tree_update_inner(tree_old[k], tree_up[k])
+                else:
+                    tree_old[k] = tree_up[k]
 
         def tree_update(tree_old: Dict, tree_raw: Dict) -> Dict:
             """
@@ -137,7 +147,7 @@ def manifests(up_name: str, gen_vers: List[str], down_grade: bool):
             """
             tree_new = copy.deepcopy(tree_old)
 
-            tree_new.update(tree_update_inner("k", tree_raw)["k"])
+            tree_update_inner(tree_new, tree_parse_inner("k", tree_raw)["k"])
 
             return tree_new
 
@@ -613,11 +623,13 @@ def manifests(up_name: str, gen_vers: List[str], down_grade: bool):
 
             riko_yaml_source = {}
             riko_yaml_cbs = {}
+            # initial packages-index toml cfgs from "source" section in riko.yaml
             if "source" in riko_yaml.keys():
                 riko_yaml_source = tree_update({"format": riko_yaml["format"]}, riko_yaml["source"])
 
             for i in range(0, len(gen_cbs)):
                 if gen_cbs[i] in riko_yaml.keys():
+                    # update toml cfgs from each package section in riko.yaml
                     riko_yaml_ast = tree_update(riko_yaml_source, riko_yaml[gen_cbs[i]])
 
                     old_version = gen_cbs_ov[i].get_version()

--- a/ruyi_packages/board-image/revyos-lcon4a/riko.py
+++ b/ruyi_packages/board-image/revyos-lcon4a/riko.py
@@ -11,50 +11,5 @@ def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     :return:
     """
 
-    # combos share same upstream object
-    upstream: RegexUpstream = new_pkgs[0].get_upstream()
-    upstream_version: str = new_pkgs[0].get_upstream_version()
-
-    assert upstream.source == "regex"
-
-    # get files from upstream
-    boot, boot_url = upstream.get_release_assert_regex("^boot-.+\\.ext4")
-    root, root_url = upstream.get_release_assert_regex("^root-.+\\.ext4")
-    uboot_8g, uboot_8g_url = upstream.get_release_assert_substring("u-boot-with-spl-lcon4a.bin")
-    uboot_16g, uboot_16g_url = upstream.get_release_assert_substring("-16g")
-
-    for i in range(0, len(old_pkgs)):
-        # new toml to edit
-        new_toml = new_pkgs[i].get_manifest()[0]
-        # edit metadata.desc
-        new_toml["metadata"]["desc"] = (new_toml["metadata"]["desc"].replace(old_pkgs[i].get_upstream_version(),
-                                        new_pkgs[i].get_upstream_version()))
-        # generate new version
-        new_pkgs[i].version = old_pkgs[i].get_version().replace(minor=upstream_version, patch=0)
-
-        if old_pkgs[i].get_combo() == "revyos-sipeed-lcon4a":
-            new_toml["distfiles"][0]["name"] = boot
-            new_toml["distfiles"][0]["urls"] = [boot_url]
-            new_toml["distfiles"][1]["name"] = root
-            new_toml["distfiles"][1]["urls"] = [root_url]
-            new_toml["blob"]["distfiles"] = [boot, root]
-            # manually set `provisionable.partition_map` for `fastboot-v1` strategy
-            # riko will help with handling .zst suffix
-            new_toml["provisionable"]["partition_map"] = {"boot": boot, "root": root}
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-sipeed-lcon4a-8g":
-            # there is a rename in this toml, use old format
-            new_toml["distfiles"][0]["name"] = uboot_8g
-            new_toml["blob"]["distfiles"] = [uboot_8g]
-            new_toml["distfiles"][0]["urls"] = [uboot_8g_url]
-            # provisionable.partition_map will automatically set for `fastboot-v1(lpi4a-uboot)` strategy
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-sipeed-lcon4a-16g":
-            new_toml["distfiles"][0]["name"] = uboot_16g
-            new_toml["blob"]["distfiles"] = [uboot_16g]
-            new_toml["distfiles"][0]["urls"] = [uboot_16g_url]
-
-        else:
-            raise RuntimeError(f"Unknown combo {old_pkgs[i].get_combo()}")
-
-        new_pkgs[i].set_manifest_ready()
+    for p in new_pkgs:
+        p.get_manifest()[0]["distfiles"][0]["urls"][0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")

--- a/ruyi_packages/board-image/revyos-lcon4a/riko.py
+++ b/ruyi_packages/board-image/revyos-lcon4a/riko.py
@@ -3,7 +3,7 @@ from typing import List
 from riko.api import RikoPkg, RegexUpstream
 
 
-def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+def post_rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     """
     old toml stored in old_pkg, format new toml to new_pkg
     :param old_pkgs: old pkg list
@@ -12,4 +12,6 @@ def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     """
 
     for p in new_pkgs:
-        p.get_manifest()[0]["distfiles"][0]["urls"][0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")
+        for d in p.get_manifest()[0]["distfiles"]:
+            urls = d["urls"]
+            urls[0] = urls[0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")

--- a/ruyi_packages/board-image/revyos-lcon4a/riko.toml
+++ b/ruyi_packages/board-image/revyos-lcon4a/riko.toml
@@ -15,6 +15,6 @@ image-combo = [
     "uboot-revyos-sipeed-lcon4a-16g"
 ]
 
-[policies]
-uboot-revyos-sipeed-lcon4a-8g = ["keep_back"]
-uboot-revyos-sipeed-lcon4a-16g = ["keep_back"]
+# [policies]
+# uboot-revyos-sipeed-lcon4a-8g = ["keep_back"]
+# uboot-revyos-sipeed-lcon4a-16g = ["keep_back"]

--- a/ruyi_packages/board-image/revyos-lcon4a/riko.yaml
+++ b/ruyi_packages/board-image/revyos-lcon4a/riko.yaml
@@ -1,0 +1,28 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RevyOS {upstream_version} image for Sipeed Lichee Console 4A"
+    vendor:
+      name: Sipeed
+      eula:
+
+revyos-sipeed-lcon4a:
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: boot(regex("^boot-.+\\.ext4"))
+    - name: root(regex("^root-.+\\.ext4"))
+
+uboot-revyos-sipeed-lcon4a-8g:
+  metadata:
+    desc: f"U-Boot image for Sipeed Lichee Console 4A (8G RAM) and RevyOS {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("u-boot-with-spl-lcon4a.bin"))
+
+uboot-revyos-sipeed-lcon4a-16g:
+  metadata:
+    desc: f"U-Boot image for Sipeed Lichee Console 4A (16G RAM) and RevyOS {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("-16g"))

--- a/ruyi_packages/board-image/revyos-lpi4a/riko.py
+++ b/ruyi_packages/board-image/revyos-lpi4a/riko.py
@@ -3,7 +3,7 @@ from typing import List
 from riko.api import RikoPkg, RegexUpstream
 
 
-def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+def post_rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     """
     old toml stored in old_pkg, format new toml to new_pkg
     :param old_pkgs: old pkg list
@@ -11,54 +11,7 @@ def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     :return:
     """
 
-    # combos share same upstream object
-    upstream: RegexUpstream = new_pkgs[0].get_upstream()
-    upstream_version: str = new_pkgs[0].get_upstream_version()
-
-    assert upstream.source == "regex"
-
-    # get files from upstream
-    boot, boot_url = upstream.get_release_assert_regex("^boot-.+\\.ext4")
-    root, root_url = upstream.get_release_assert_regex("^root-.+\\.ext4")
-    _, uboot_8g_url = upstream.get_release_assert_substring("u-boot-with-spl-lpi4a-main.bin")
-    _, uboot_16g_url = upstream.get_release_assert_substring("u-boot-with-spl-lpi4a-16g")
-
-    for i in range(0, len(old_pkgs)):
-        # new toml to edit
-        new_toml = new_pkgs[i].get_manifest()[0]
-        # edit metadata.desc
-        new_toml["metadata"]["desc"] = (new_toml["metadata"]["desc"].replace(old_pkgs[i].get_upstream_version(),
-                                        new_pkgs[i].get_upstream_version()))
-        # generate new version
-        new_pkgs[i].version = old_pkgs[i].get_version().replace(minor=upstream_version, patch=0)
-
-        if old_pkgs[i].get_combo() == "revyos-sipeed-lpi4a":
-            new_toml["distfiles"][0]["name"] = boot
-            new_toml["distfiles"][0]["urls"] = [boot_url]
-            new_toml["distfiles"][1]["name"] = root
-            new_toml["distfiles"][1]["urls"] = [root_url]
-            new_toml["blob"]["distfiles"] = [boot, root]
-            # manually set `provisionable.partition_map` for `fastboot-v1` strategy
-            # riko will help with handling .zst suffix
-            new_toml["provisionable"]["partition_map"] = {"boot": boot, "root": root}
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-sipeed-lpi4a-8g":
-            # there is a rename in this toml, use old format
-            bin_name = new_toml["distfiles"][0]["name"].replace(old_pkgs[i].get_upstream_version(),
-                                                        new_pkgs[i].get_upstream_version())
-            new_toml["distfiles"][0]["name"] = bin_name
-            new_toml["blob"]["distfiles"] = [bin_name]
-            new_toml["distfiles"][0]["urls"] = [uboot_8g_url]
-            # provisionable.partition_map will automatically set for `fastboot-v1(lpi4a-uboot)` strategy
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-sipeed-lpi4a-16g":
-            bin_name = new_toml["distfiles"][0]["name"].replace(old_pkgs[i].get_upstream_version(),
-                                                        new_pkgs[i].get_upstream_version())
-            new_toml["distfiles"][0]["name"] = bin_name
-            new_toml["blob"]["distfiles"] = [bin_name]
-            new_toml["distfiles"][0]["urls"] = [uboot_16g_url]
-
-        else:
-            raise RuntimeError(f"Unknown combo {old_pkgs[i].get_combo()}")
-
-        new_pkgs[i].set_manifest_ready()
+    for p in new_pkgs:
+        for d in p.get_manifest()[0]["distfiles"]:
+            urls = d["urls"]
+            urls[0] = urls[0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")

--- a/ruyi_packages/board-image/revyos-lpi4a/riko.toml
+++ b/ruyi_packages/board-image/revyos-lpi4a/riko.toml
@@ -15,10 +15,10 @@ image-combo = [
     "uboot-revyos-sipeed-lpi4a-16g"
 ]
 
-[policies]
+# [policies]
 # uboot not upgrade in each release
 # sometimes their hashes are the same with old version
 # see: https://github.com/ruyisdk/packages-index/pull/76
 # so use `keep_back` policy here
-uboot-revyos-sipeed-lpi4a-8g = ["keep_back"]
-uboot-revyos-sipeed-lpi4a-16g = ["keep_back"]
+# uboot-revyos-sipeed-lpi4a-8g = ["keep_back"]
+# uboot-revyos-sipeed-lpi4a-16g = ["keep_back"]

--- a/ruyi_packages/board-image/revyos-lpi4a/riko.yaml
+++ b/ruyi_packages/board-image/revyos-lpi4a/riko.yaml
@@ -1,0 +1,28 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RevyOS {upstream_version} image for Sipeed LicheePi 4A"
+    vendor:
+      name: PLCT
+      eula:
+
+revyos-sipeed-lpi4a:
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: boot(regex("^boot-.+\\.ext4"))
+    - name: root(regex("^root-.+\\.ext4"))
+
+uboot-revyos-sipeed-lpi4a-8g:
+  metadata:
+    desc: f"U-Boot image for LicheePi 4A (8G RAM) and RevyOS {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("u-boot-with-spl-lpi4a-main.bin"))
+
+uboot-revyos-sipeed-lpi4a-16g:
+  metadata:
+    desc: f"U-Boot image for LicheePi 4A (16G RAM) and RevyOS {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("u-boot-with-spl-lpi4a-16g"))

--- a/ruyi_packages/board-image/revyos-lpi4amain/riko.toml
+++ b/ruyi_packages/board-image/revyos-lpi4amain/riko.toml
@@ -10,6 +10,6 @@ image-combo = [
     "uboot-revyos-sipeed-lc4a-16g"
 ]
 
-[policies]
-uboot-revyos-sipeed-lc4a-8g = ["keep_back"]
-uboot-revyos-sipeed-lc4a-16g = ["keep_back"]
+# [policies]
+# uboot-revyos-sipeed-lc4a-8g = ["keep_back"]
+# uboot-revyos-sipeed-lc4a-16g = ["keep_back"]

--- a/ruyi_packages/board-image/revyos-meles/riko.toml
+++ b/ruyi_packages/board-image/revyos-meles/riko.toml
@@ -16,7 +16,7 @@ image-combo = [
     "uboot-revyos-milkv-meles-16g"
 ]
 
-[policies]
-uboot-revyos-milkv-meles-4g = ["keep_back"]
-uboot-revyos-milkv-meles-8g = ["keep_back"]
-uboot-revyos-milkv-meles-16g = ["keep_back"]
+# [policies]
+# uboot-revyos-milkv-meles-4g = ["keep_back"]
+# uboot-revyos-milkv-meles-8g = ["keep_back"]
+# uboot-revyos-milkv-meles-16g = ["keep_back"]


### PR DESCRIPTION
## Summary by Sourcery

Enable new riko.yaml v1 format and simplify manifest generation by consolidating URL rewriting, enhancing parsing logic, and disabling obsolete policies

New Features:
- Add riko.yaml v1 manifest configurations for revyos-lcon4a and revyos-lpi4a with shared source metadata and package-specific distfiles definitions

Enhancements:
- Replace complex rikoring logic with a post_rikoring hook that uniformly rewrites distfile URLs to use the mirror:// prefix
- Refactor CLI manifest parsing by renaming and splitting tree_parse_inner and tree_update_inner functions and updating tree_update to merge source and package-specific configs

Chores:
- Comment out legacy policies sections in multiple revyos board-image riko.toml files to disable outdated keep_back rules