### PR TITLE
New format for revyos-{sg2042,meles,lpi4amain}

### DIFF
--- a/ruyi_packages/board-image/revyos-lpi4amain/riko.py
+++ b/ruyi_packages/board-image/revyos-lpi4amain/riko.py
@@ -1,0 +1,17 @@
+from typing import List
+
+from riko.api import RikoPkg, RegexUpstream
+
+
+def post_rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+    """
+    old toml stored in old_pkg, format new toml to new_pkg
+    :param old_pkgs: old pkg list
+    :param new_pkgs: new pkg list
+    :return:
+    """
+
+    for p in new_pkgs:
+        for d in p.get_manifest()[0]["distfiles"]:
+            urls = d["urls"]
+            urls[0] = urls[0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")

--- a/ruyi_packages/board-image/revyos-lpi4amain/riko.yaml
+++ b/ruyi_packages/board-image/revyos-lpi4amain/riko.yaml
@@ -1,0 +1,28 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RevyOS {upstream_version} image for Sipeed Lichee Cluster 4A"
+    vendor:
+      name: PLCT
+      eula:
+
+revyos-sipeed-lc4a:
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: boot(regex("^boot-.+\\.ext4"))
+    - name: root(regex("^root-.+\\.ext4"))
+
+uboot-revyos-sipeed-lc4a-8g:
+  metadata:
+    desc: f"U-Boot image for Sipeed Lichee Cluster 4A (8G RAM) and RevyOS {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("u-boot-with-spl-lc4a-main.bin"))
+
+uboot-revyos-sipeed-lc4a-16g:
+  metadata:
+    desc: f"U-Boot image for Sipeed Lichee Cluster 4A (16G RAM) and RevyOS {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("u-boot-with-spl-lc4a-16g-main.bin"))

--- a/ruyi_packages/board-image/revyos-meles/riko.py
+++ b/ruyi_packages/board-image/revyos-meles/riko.py
@@ -3,7 +3,7 @@ from typing import List
 from riko.api import RikoPkg, RegexUpstream
 
 
-def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+def post_rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     """
     old toml stored in old_pkg, format new toml to new_pkg
     :param old_pkgs: old pkg list
@@ -11,62 +11,7 @@ def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     :return:
     """
 
-    # combos share same upstream object
-    upstream: RegexUpstream = new_pkgs[0].get_upstream()
-    upstream_version: str = new_pkgs[0].get_upstream_version()
-
-    assert upstream.source == "regex"
-
-    # get files from upstream
-    boot, boot_url = upstream.get_release_assert_regex("^boot-.+\\.ext4")
-    root, root_url = upstream.get_release_assert_regex("^root-.+\\.ext4")
-    _, uboot_4g_url = upstream.get_release_assert_substring("-4g")
-    _, uboot_8g_url = upstream.get_release_assert_substring("u-boot-with-spl-meles.bin")
-    _, uboot_16g_url = upstream.get_release_assert_substring("-16g")
-
-    for i in range(0, len(old_pkgs)):
-        # new toml to edit
-        new_toml = new_pkgs[i].get_manifest()[0]
-        # edit metadata.desc
-        new_toml["metadata"]["desc"] = (new_toml["metadata"]["desc"].replace(old_pkgs[i].get_upstream_version(),
-                                        new_pkgs[i].get_upstream_version()))
-        # generate new version
-        new_pkgs[i].version = old_pkgs[i].get_version().replace(minor=upstream_version, patch=0)
-
-        if old_pkgs[i].get_combo() == "revyos-milkv-meles":
-            new_toml["distfiles"][0]["name"] = boot
-            new_toml["distfiles"][0]["urls"] = [boot_url]
-            new_toml["distfiles"][1]["name"] = root
-            new_toml["distfiles"][1]["urls"] = [root_url]
-            new_toml["blob"]["distfiles"] = [boot, root]
-            # manually set `provisionable.partition_map` for `fastboot-v1` strategy
-            # riko will help with handling .zst suffix
-            new_toml["provisionable"]["partition_map"] = {"boot": boot, "root": root}
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-milkv-meles-8g":
-            # there is a rename in this toml, use old format
-            bin_name = new_toml["distfiles"][0]["name"].replace(old_pkgs[i].get_upstream_version(),
-                                                        new_pkgs[i].get_upstream_version())
-            new_toml["distfiles"][0]["name"] = bin_name
-            new_toml["blob"]["distfiles"] = [bin_name]
-            new_toml["distfiles"][0]["urls"] = [uboot_8g_url]
-            # provisionable.partition_map will automatically set for `fastboot-v1(lpi4a-uboot)` strategy
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-milkv-meles-16g":
-            bin_name = new_toml["distfiles"][0]["name"].replace(old_pkgs[i].get_upstream_version(),
-                                                        new_pkgs[i].get_upstream_version())
-            new_toml["distfiles"][0]["name"] = bin_name
-            new_toml["blob"]["distfiles"] = [bin_name]
-            new_toml["distfiles"][0]["urls"] = [uboot_16g_url]
-
-        elif old_pkgs[i].get_combo() == "uboot-revyos-milkv-meles-4g":
-            bin_name = new_toml["distfiles"][0]["name"].replace(old_pkgs[i].get_upstream_version(),
-                                                        new_pkgs[i].get_upstream_version())
-            new_toml["distfiles"][0]["name"] = bin_name
-            new_toml["blob"]["distfiles"] = [bin_name]
-            new_toml["distfiles"][0]["urls"] = [uboot_4g_url]
-
-        else:
-            raise RuntimeError(f"Unknown combo {old_pkgs[i].get_combo()}")
-
-        new_pkgs[i].set_manifest_ready()
+    for p in new_pkgs:
+        for d in p.get_manifest()[0]["distfiles"]:
+            urls = d["urls"]
+            urls[0] = urls[0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")

--- a/ruyi_packages/board-image/revyos-meles/riko.yaml
+++ b/ruyi_packages/board-image/revyos-meles/riko.yaml
@@ -1,0 +1,35 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RevyOS {upstream_version} image for Milk-V Meles"
+    vendor:
+      name: Milk-V
+      eula:
+
+revyos-milkv-meles:
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: boot(regex("^boot-.+\\.ext4"))
+    - name: root(regex("^root-.+\\.ext4"))
+
+uboot-revyos-milkv-meles-4g:
+  metadata:
+    desc: f"U-Boot image for Milk-V Meles (Single-rank, 4G RAM), for RevyOS, {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("-4g"))
+
+uboot-revyos-milkv-meles-8g:
+  metadata:
+    desc: f"U-Boot image for Milk-V Meles (Dual-rank, 8G RAM), for RevyOS, {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("u-boot-with-spl-meles.bin"))
+
+uboot-revyos-milkv-meles-16g:
+  metadata:
+    desc: f"U-Boot image for Milk-V Meles (Dual-rank, 16G RAM), for RevyOS, {upstream_version}"
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: uboot(substring("-16g"))

--- a/ruyi_packages/board-image/revyos-sg2042/riko.py
+++ b/ruyi_packages/board-image/revyos-sg2042/riko.py
@@ -3,7 +3,7 @@ from typing import List
 from riko.api import RikoPkg, GithubUpstream
 
 
-def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+def post_rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     """
     old toml stored in old_pkg, format new toml to new_pkg
     :param old_pkgs: old pkg list
@@ -11,19 +11,5 @@ def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     :return:
     """
 
-    upstream: GithubUpstream = new_pkgs[0].get_upstream()
-    upstream_version: str = new_pkgs[0].get_upstream_version()
-    assert upstream.source == "regex"
-
-    img, img_url = upstream.get_release_assert_regex(fr"revyos-pioneer-{upstream_version}-\d+\.img\.zst")
-
-    new_pkgs[0].version = old_pkgs[0].version.replace(minor=upstream_version, patch=0)
-
-    new_toml = new_pkgs[0].get_manifest()[0]
-    new_toml["metadata"]["desc"] = (new_toml["metadata"]["desc"].replace(old_pkgs[0].get_upstream_version(),
-                                                                         new_pkgs[0].get_upstream_version()))
-    new_toml["blob"]["distfiles"] = [img]
-    new_toml["distfiles"][0]["name"] = img
-    new_toml["distfiles"][0]["urls"] = [img_url]
-
-    new_pkgs[0].set_manifest_ready()
+    urls = new_pkgs[0].get_manifest()[0]["distfiles"][0]["urls"]
+    urls[0] = urls[0].replace("https://mirror.iscas.ac.cn/revyos/", "mirror://revyos/")

--- a/ruyi_packages/board-image/revyos-sg2042/riko.yaml
+++ b/ruyi_packages/board-image/revyos-sg2042/riko.yaml
@@ -1,0 +1,13 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RevyOS {upstream_version} image for Milk-V Pioneer Box with SG2042"
+    vendor:
+      name: PLCT
+      eula:
+
+revyos-milkv-pioneer:
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: disk(regex(fr"revyos-pioneer-{upstream_version}-\d+\.img\.zst"))


### PR DESCRIPTION
## Summary by Sourcery

Migrate board-image packaging for RevyOS on SG2042, Meles, and Lichee Cluster 4A to a unified YAML v1 manifest format and streamline post-processing by consolidating URL rewriting into a generic hook.

New Features:
- Add v1 riko.yaml manifests for revyos-meles, revyos-sg2042, and revyos-lpi4amain boards

Enhancements:
- Replace legacy rikoring implementations with a simplified post_rikoring hook that standardizes distfile URLs to mirror://revyos/
- Rename rikoring function to post_rikoring across all packaging scripts