### PR TITLE
Change revyos-{lcon4a,meles} vendor name to PLCT

### DIFF
--- a/ruyi_packages/board-image/revyos-lcon4a/riko.yaml
+++ b/ruyi_packages/board-image/revyos-lcon4a/riko.yaml
@@ -4,7 +4,7 @@ source:
   metadata:
     desc: f"RevyOS {upstream_version} image for Sipeed Lichee Console 4A"
     vendor:
-      name: Sipeed
+      name: PLCT
       eula:
 
 revyos-sipeed-lcon4a:

--- a/ruyi_packages/board-image/revyos-meles/riko.yaml
+++ b/ruyi_packages/board-image/revyos-meles/riko.yaml
@@ -4,7 +4,7 @@ source:
   metadata:
     desc: f"RevyOS {upstream_version} image for Milk-V Meles"
     vendor:
-      name: Milk-V
+      name: PLCT
       eula:
 
 revyos-milkv-meles:


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Unify the vendor name to PLCT in the metadata of revyos-lcon4a and revyos-meles board images