### PR TITLE
ruyi_packages: add bianbu-k1 emmc image support

### DIFF
--- a/ruyi_packages/board-image/bianbu-k1/riko.py
+++ b/ruyi_packages/board-image/bianbu-k1/riko.py
@@ -10,39 +10,3 @@ def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
     :param new_pkgs: new pkg list
     :return:
     """
-
-    # set versions
-    upstream_version_orig: str = new_pkgs[0].get_upstream_version()
-    # v2.1 -> 2.1
-    upstream_version = upstream_version_orig[1:]
-    # 2.1 -> 2.1.0
-    if upstream_version.count(".") == 1:
-        upstream_version += ".0"
-    assert upstream_version.count(".") == 2
-
-    for p in new_pkgs:
-        p.version = p.get_version().parse(upstream_version)
-
-    # get files from upstream
-    upstream: RegexUpstream = new_pkgs[0].get_upstream()
-    assert upstream.source == "regex"
-    desktop, desktop_url = upstream.get_release_assert_regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version_orig}-release-[\\d]+.img.zip$")
-    minimal, minimal_url = upstream.get_release_assert_regex(f"^bianbu-[\\d]+\\.[\\d]+-minimal-k1-{upstream_version_orig}-release-[\\d]+.img.zip$")
-
-    for i in range(0, len(old_pkgs)):
-        # set metadata.desc
-        new_toml: Dict = new_pkgs[i].get_manifest()[0]
-        new_toml["metadata"]["desc"] = new_toml["metadata"]["desc"].replace(old_pkgs[i].get_upstream_version(), upstream_version_orig)
-
-        if old_pkgs[i].get_combo() == "bianbu-desktop-spacemit-k1-sd":
-            new_toml["distfiles"][0]["name"] = desktop
-            new_toml["distfiles"][0]["urls"] = [desktop_url]
-            new_toml["blob"]["distfiles"] = [desktop]
-        elif old_pkgs[i].get_combo() == "bianbu-minimal-spacemit-k1-sd":
-            new_toml["distfiles"][0]["name"] = minimal
-            new_toml["distfiles"][0]["urls"] = [minimal_url]
-            new_toml["blob"]["distfiles"] = [minimal]
-        else:
-            raise RuntimeError(f"Unknown combo {old_pkgs[i].get_combo()}")
-
-        new_pkgs[i].set_manifest_ready()

--- a/ruyi_packages/board-image/bianbu-k1/riko.toml
+++ b/ruyi_packages/board-image/bianbu-k1/riko.toml
@@ -10,6 +10,8 @@ regex_file_regex = '<a href="(bianbu.+)">bianbu.+</a>'
 
 [entities]
 image-combo = [
+    "bianbu-minimal-spacemit-k1",
+    "bianbu-desktop-spacemit-k1",
     "bianbu-minimal-spacemit-k1-sd",
-    "bianbu-desktop-spacemit-k1-sd"
+    "bianbu-desktop-spacemit-k1-sd",
 ]

--- a/ruyi_packages/board-image/bianbu-k1/riko.yaml
+++ b/ruyi_packages/board-image/bianbu-k1/riko.yaml
@@ -1,0 +1,25 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"Official Bianbu Desktop {upstream_version} for SpacemiT K1"
+    vendor:
+      name: SpacemiT
+      eula:
+  version: version(major=(_v := upstream_version[1:].split("."))[0], minor=_v[1], patch=_v[2] if len(_v) > 2 else 0)
+
+bianbu-minimal-spacemit-k1:
+  distfiles:
+    - name: titan(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.zip$"))
+
+bianbu-desktop-spacemit-k1:
+  distfiles:
+    - name: titan(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.zip$"))
+
+bianbu-desktop-spacemit-k1-sd:
+  distfiles:
+    - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.img.zip$"))
+
+bianbu-minimal-spacemit-k1-sd:
+  distfiles:
+    - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-minimal-k1-{upstream_version}-release-[\\d]+.img.zip$"))


### PR DESCRIPTION
## Summary by Sourcery

Replace the custom riko.py recipe with a declarative riko.yaml manifest and update riko.toml to include new eMMC (non-SD) image combos for bianbu-k1

New Features:
- Add eMMC image support by introducing non-SD minimal and desktop bianbu-k1 image combos

Enhancements:
- Migrate bianbu-k1 board-image recipe from imperative Python script to declarative YAML manifest
- Remove legacy rikoring logic