### PR TITLE
ruyi_packages: add bianbu-k1 desktop lite images

### DIFF
--- a/ruyi_packages/board-image/bianbu-k1/riko.toml
+++ b/ruyi_packages/board-image/bianbu-k1/riko.toml
@@ -11,7 +11,9 @@ regex_file_regex = '<a href="(bianbu.+)">bianbu.+</a>'
 [entities]
 image-combo = [
     "bianbu-minimal-spacemit-k1",
-    "bianbu-desktop-spacemit-k1",
     "bianbu-minimal-spacemit-k1-sd",
+    "bianbu-desktop-spacemit-k1",
     "bianbu-desktop-spacemit-k1-sd",
+    "bianbu-desktop-lite-spacemit-k1",
+    "bianbu-desktop-lite-spacemit-k1-sd",
 ]

--- a/ruyi_packages/board-image/bianbu-k1/riko.yaml
+++ b/ruyi_packages/board-image/bianbu-k1/riko.yaml
@@ -25,8 +25,20 @@ bianbu-minimal-spacemit-k1-sd:
   distfiles:
     - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-minimal-k1-{upstream_version}-release-[\\d]+.img.zip$"))
 
+bianbu-desktop-lite-spacemit-k1:
+  metadata:
+    desc: f"Official Bianbu Desktop Lite {upstream_version} for SpacemiT K1"
+  distfiles:
+    - name: titan(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-lite-k1-{upstream_version}-release-[\\d]+.zip$"))
+
 bianbu-desktop-spacemit-k1-sd:
   metadata:
     desc: f"Official Bianbu Desktop {upstream_version} for SpacemiT K1"
   distfiles:
     - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.img.zip$"))
+
+bianbu-desktop-lite-spacemit-k1-sd:
+  metadata:
+    desc: f"Official Bianbu Desktop Lite {upstream_version} for SpacemiT K1"
+  distfiles:
+    - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-lite-k1-{upstream_version}-release-[\\d]+.img.zip$"))

--- a/ruyi_packages/board-image/bianbu-k1/riko.yaml
+++ b/ruyi_packages/board-image/bianbu-k1/riko.yaml
@@ -2,24 +2,31 @@ format: v1
 
 source:
   metadata:
-    desc: f"Official Bianbu Desktop {upstream_version} for SpacemiT K1"
     vendor:
       name: SpacemiT
       eula:
   version: version(major=(_v := upstream_version[1:].split("."))[0], minor=_v[1], patch=_v[2] if len(_v) > 2 else 0)
 
 bianbu-minimal-spacemit-k1:
+  metadata:
+    desc: f"Official Bianbu Minimal {upstream_version} for SpacemiT K1"
   distfiles:
     - name: titan(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.zip$"))
 
 bianbu-desktop-spacemit-k1:
+  metadata:
+    desc: f"Official Bianbu Desktop {upstream_version} for SpacemiT K1"
   distfiles:
     - name: titan(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.zip$"))
 
-bianbu-desktop-spacemit-k1-sd:
-  distfiles:
-    - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.img.zip$"))
-
 bianbu-minimal-spacemit-k1-sd:
+  metadata:
+    desc: f"Official Bianbu Minimal {upstream_version} for SpacemiT K1"
   distfiles:
     - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-minimal-k1-{upstream_version}-release-[\\d]+.img.zip$"))
+
+bianbu-desktop-spacemit-k1-sd:
+  metadata:
+    desc: f"Official Bianbu Desktop {upstream_version} for SpacemiT K1"
+  distfiles:
+    - name: disk(regex(f"^bianbu-[\\d]+\\.[\\d]+-desktop-k1-{upstream_version}-release-[\\d]+.img.zip$"))


### PR DESCRIPTION
## Summary by Sourcery

Add new lite desktop images for the SpacemiT K1 board and enrich image metadata

Enhancements:
- Generate bianbu-desktop-lite-spacemit-k1 and bianbu-desktop-lite-spacemit-k1-sd image entries in the YAML
- Add metadata.desc to all bianbu-k1 image definitions for consistent descriptions
- Update riko.toml image-combo list to include the new lite variants and adjust entry ordering
- Remove the redundant top-level source desc from riko.yaml to centralize metadata on individual images