### PR TITLE
ruyi_packages: new package rockos-megrez

### DIFF
--- a/ruyi_packages/board-image/rockos-megrez/riko.py
+++ b/ruyi_packages/board-image/rockos-megrez/riko.py
@@ -1,0 +1,24 @@
+
+import re
+
+from typing import List
+
+from riko.api import RikoPkg, GithubUpstream
+
+
+def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+    """
+    old toml stored in old_pkg, format new toml to new_pkg
+    :param old_pkgs: old pkg list
+    :param new_pkgs: new pkg list
+    :return:
+    """
+
+    for p in new_pkgs:
+        minor = p.version.minor
+
+        img = p.get_manifest()[0]["distfiles"][0]["name"]
+        new_minor = re.findall(r"sdcard-rockos-([\d]+)-[\d]+.img.zst", img)
+
+        if new_minor and minor != new_minor[0]:
+            p.version = p.get_version().replace(minor=new_minor[0])

--- a/ruyi_packages/board-image/rockos-megrez/riko.toml
+++ b/ruyi_packages/board-image/rockos-megrez/riko.toml
@@ -1,0 +1,14 @@
+[nvchecker]
+source = "regex"
+url = "https://mirror.iscas.ac.cn/rockos/images/generic/"
+regex = '<a href="([\d.]+_[\d.]+)/">[\d.]+_[\d.]+/</a>'
+
+[source]
+# see: riko.upstreams.regex.RegexUpstream
+regex_file_url = "{{nvchecker.url}}{{upstream_version}}/"
+regex_file_regex = '<a href="(.+)">.+</a> '
+
+[entities]
+image-combo = [
+    "rockos-milkv-megrez",
+]

--- a/ruyi_packages/board-image/rockos-megrez/riko.yaml
+++ b/ruyi_packages/board-image/rockos-megrez/riko.yaml
@@ -1,0 +1,13 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RockOS {upstream_version} image for Milk-V Megrez with EIC7700"
+    vendor:
+      name: PLCT
+      eula:
+
+rockos-milkv-megrez:
+  version: version(minor=upstream_version.split('_')[1], patch=0)
+  distfiles:
+    - name: disk(substring("sdcard-rockos-"))


### PR DESCRIPTION
## Summary by Sourcery

Add a new board-image package for RockOS Megrez with Riko-based upstream tracking and version alignment

New Features:
- Add riko.toml to configure NVChecker regex source for RockOS Megrez images
- Add riko.yaml to define package metadata, version extraction, and distfile mapping for rockos-milkv-megrez
- Implement rikoring plugin in riko.py to update package versions based on image filename minor versions