### PR TITLE
ruyi_packages: new package redleafos-nanhu

### DIFF
--- a/ruyi_packages/board-image/redleafos-nanhu/riko.py
+++ b/ruyi_packages/board-image/redleafos-nanhu/riko.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from riko.api import RikoPkg, GithubUpstream
+
+
+def post_rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+    """
+    old toml stored in old_pkg, format new toml to new_pkg
+    :param old_pkgs: old pkg list
+    :param new_pkgs: new pkg list
+    :return:
+    """

--- a/ruyi_packages/board-image/redleafos-nanhu/riko.toml
+++ b/ruyi_packages/board-image/redleafos-nanhu/riko.toml
@@ -1,0 +1,14 @@
+[nvchecker]
+source = "regex"
+url = "https://mirror.iscas.ac.cn/redleafos/extra/images/"
+regex = '<a href="([\d.]+)/">[\d.]+/</a>'
+
+[source]
+# see: riko.upstreams.regex.RegexUpstream
+regex_file_url = "{{nvchecker.url}}{{upstream_version}}/"
+regex_file_regex = '<a href="(.+)">.+</a> '
+
+[entities]
+image-combo = [
+    "redleafos-xiangshan-nanhu",
+]

--- a/ruyi_packages/board-image/redleafos-nanhu/riko.yaml
+++ b/ruyi_packages/board-image/redleafos-nanhu/riko.yaml
@@ -1,0 +1,13 @@
+format: v1
+
+source:
+  metadata:
+    desc: f"RedleafOS {upstream_version} image for Xiangshan Nanhu"
+    vendor:
+      name: PLCT
+      eula:
+
+redleafos-xiangshan-nanhu:
+  version: version(minor=upstream_version, patch=0)
+  distfiles:
+    - name: disk(substring("debian-nanhu"))


### PR DESCRIPTION
## Summary by Sourcery

Add a new ruyi_packages board-image package for RedleafOS on the Xiangshan Nanhu board

New Features:
- Introduce riko.toml configuration with nvchecker regex source and image-combo entity for redleafos-xiangshan-nanhu
- Add riko.yaml to specify package metadata and distfile rules for the Nanhu board image
- Provide a stubbed riko.py script implementing a post_rikoring hook for formatting new package definitions