### PR TITLE
ruyi_packages: update file match regex for revyos-lpi4a

### DIFF
--- a/ruyi_packages/board-image/revyos-lpi4a/riko.yaml
+++ b/ruyi_packages/board-image/revyos-lpi4a/riko.yaml
@@ -18,7 +18,7 @@ uboot-revyos-sipeed-lpi4a-8g:
     desc: f"U-Boot image for LicheePi 4A (8G RAM) and RevyOS {upstream_version}"
   version: version(minor=upstream_version, patch=0)
   distfiles:
-    - name: uboot(substring("u-boot-with-spl-lpi4a-main.bin"))
+    - name: uboot(regex("u-boot-with-spl-lpi4a(-main)?.bin"))
 
 uboot-revyos-sipeed-lpi4a-16g:
   metadata:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the revyos-lpi4a U-Boot artifact is correctly matched whether or not the file name includes the "-main" infix.