### PR TITLE
add Muse pi pro

### DIFF
--- a/ruyi_packages/board-image/armbian/riko.py
+++ b/ruyi_packages/board-image/armbian/riko.py
@@ -5,37 +5,75 @@ from typing import List, Dict, Tuple
 from riko.api import RikoPkg, GithubUpstream
 
 
+# def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+#
+#     # First, get new toml, some items such as upstream_version will automatically set.
+#     # NOTE that `old_pkgs` is read only, do not modify it to prevent unexpected result
+#     # Note that this package only has one combo
+#     new_toml: Dict = new_pkgs[0].get_manifest()[0]
+#     upstream: GithubUpstream = new_pkgs[0].get_upstream()
+#     upstream_version: str = new_pkgs[0].get_upstream_version()
+#
+#     assert upstream.source == "github"
+#
+#     # Second, generate new version
+#     # Upstream version is ruyi version
+#     new_pkgs[0].version = semver.Version.parse(upstream_version)
+#
+#     # Third, edit metadata.desc
+#     new_toml["metadata"]["desc"] = (
+#         new_toml["metadata"]["desc"].replace(old_pkgs[0].get_upstream_version(), new_pkgs[0].get_upstream_version()))
+#
+#     # See: https://github.com/ruyisdk/support-matrix/issues/353
+#     # Fourth, get file
+#     # assets = upstream.get_release_asserts(upstream_version)
+#     # files: List[Tuple[str, str]] = []
+#     # for asset in assets:
+#     #    if "Star64_noble" in asset.name and asset.name[-1] == "z":
+#     #        files.append((asset.name, asset.browser_download_url))
+#
+#     # assert len(files) == 1
+#     # new_toml["blob"]["distfiles"] = [files[0][0], ]
+#     # new_toml["distfiles"][0]["name"] = files[0][0]
+#     # new_toml["distfiles"][0]["urls"] = [files[0][1], ]
+#
+#     # finally, set flag to ask riko package new one
+#     # new_pkgs[0].set_manifest_ready()
+
 def rikoring(old_pkgs: List[RikoPkg], new_pkgs: List[RikoPkg]) -> None:
+    """
+    Support multiple entities (image-combo), instead of only one.
+    """
 
-    # First, get new toml, some items such as upstream_version will automatically set.
-    # NOTE that `old_pkgs` is read only, do not modify it to prevent unexpected result
-    # Note that this package only has one combo
-    new_toml: Dict = new_pkgs[0].get_manifest()[0]
-    upstream: GithubUpstream = new_pkgs[0].get_upstream()
-    upstream_version: str = new_pkgs[0].get_upstream_version()
+    # 遍历所有 package（支持多个 board）
+    for i in range(len(new_pkgs)):
 
-    assert upstream.source == "github"
+        # First, get new toml, some items such as upstream_version will automatically set.
+        new_toml: Dict = new_pkgs[i].get_manifest()[0]
 
-    # Second, generate new version
-    # Upstream version is ruyi version
-    new_pkgs[0].version = semver.Version.parse(upstream_version)
+        upstream: GithubUpstream = new_pkgs[i].get_upstream()
+        upstream_version: str = new_pkgs[i].get_upstream_version()
 
-    # Third, edit metadata.desc
-    new_toml["metadata"]["desc"] = (
-        new_toml["metadata"]["desc"].replace(old_pkgs[0].get_upstream_version(), new_pkgs[0].get_upstream_version()))
+        assert upstream.source == "github"
 
-    # See: https://github.com/ruyisdk/support-matrix/issues/353
-    # Fourth, get file
-    # assets = upstream.get_release_asserts(upstream_version)
-    # files: List[Tuple[str, str]] = []
-    # for asset in assets:
-    #    if "Star64_noble" in asset.name and asset.name[-1] == "z":
-    #        files.append((asset.name, asset.browser_download_url))
+        # Second, generate new version
+        new_pkgs[i].version = semver.Version.parse(upstream_version)
 
-    # assert len(files) == 1
-    # new_toml["blob"]["distfiles"] = [files[0][0], ]
-    # new_toml["distfiles"][0]["name"] = files[0][0]
-    # new_toml["distfiles"][0]["urls"] = [files[0][1], ]
+        # Third, edit metadata.desc
+        if old_pkgs and i < len(old_pkgs):
+            try:
+                old_version = old_pkgs[i].get_upstream_version()
 
-    # finally, set flag to ask riko package new one
-    # new_pkgs[0].set_manifest_ready()
+                new_toml["metadata"]["desc"] = (
+                    new_toml["metadata"]["desc"]
+                    .replace(old_version, upstream_version)
+                )
+            except Exception:
+
+                new_toml["metadata"]["desc"] = f"Armbian image ({upstream_version})"
+        else:
+
+            new_toml["metadata"]["desc"] = f"Armbian image ({upstream_version})"
+
+        # finally, set flag to ask riko package new one
+        new_pkgs[i].set_manifest_ready()

--- a/ruyi_packages/board-image/armbian/riko.toml
+++ b/ruyi_packages/board-image/armbian/riko.toml
@@ -6,7 +6,9 @@ use_latest_release = true
 [entities]
 image-combo = [
     "armbian-pine64-star64",
+    "armbian-muse-pi-pro"
 ]
 
 [policies]
 armbian-pine64-star64 = ["skip"]
+armbian-muse-pi-pro = ["skip"]

--- a/ruyi_packages/board-image/armbian/riko.yaml
+++ b/ruyi_packages/board-image/armbian/riko.yaml
@@ -1,0 +1,30 @@
+format: v1
+
+# 全局源配置 (参考 bianbu 的写法)
+source:
+  metadata:
+    vendor:
+      name: Armbian
+      eula: "GPL-2.0-or-later"
+  # Armbian 的版本号通常直接就是 release tag (如 24.04.1)，不需要像 bianbu 那样去掉 'v' 前缀
+  # 如果 upstream_version 带有 'v' 前缀，请取消下面这行的注释并调整逻辑
+  # version: version(major=(_v := upstream_version.lstrip('v').split("."))[0], minor=_v[1], patch=_v[2] if len(_v) > 2 else 0)
+
+# 定义 Muse Pi Pro 的包配置
+armbian-muse-pi-pro:
+  metadata:
+    # 动态描述，包含版本号
+    desc: f"Armbian Linux for Muse Pi Pro ({upstream_version})"
+    arch: "aarch64"
+
+  distfiles:
+    # 关键逻辑：
+    # 1. 使用 regex 匹配文件名。
+    #    请根据 GitHub 实际文件名调整正则！
+    #    假设文件名为: Armbian_MusePiPro_24.04.1_noble_current.img.xz
+    #    或者: armbian-muse-pi-pro-24.04.1.img.xz
+    # 2. 使用 disk() 包裹，因为这是 .img.xz 整盘镜像，对应 manifest 中的 partition_map: disk
+    - name: disk(regex(f"^.*[Mm]use[Pp][Ii]?[Pp][Rr][Oo].*\\.img\\.xz$"))
+
+    # 💡 备选方案：如果上面的正则太宽泛，可以使用更精确的匹配
+    # - name: disk(regex(f"^Armbian_MusePiPro_[\\d]+\\.[\\d]+.*\\.img\\.xz$"))


### PR DESCRIPTION
add Muse pi pro support.

## Summary by Sourcery

Add support for Armbian Muse Pi Pro images and generalize Armbian riko packaging to handle multiple image-combo entities.

New Features:
- Introduce Armbian Muse Pi Pro image-combo configuration and packaging metadata.

Enhancements:
- Generalize the Armbian riko rikoring helper to process multiple image-combo entities and robustly update package metadata descriptions.